### PR TITLE
import from correct files

### DIFF
--- a/engine_finetune.py
+++ b/engine_finetune.py
@@ -18,9 +18,9 @@ from timm.data import Mixup
 from timm.utils import accuracy, ModelEma
 
 import utils
-from utils import adjust_learning_rate
+from utils import adjust_learning_rate, visualize_segmentation
 from timm.loss import LabelSmoothingCrossEntropy
-from custom_func_finetune import DiceLoss, visualize_segmentation
+from custom_loss import DiceLoss
 
 
 def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,


### PR DESCRIPTION
When I tried to run `./slurm_scripts/slurm_fine_tune_seg.sh`, I ran into the following error:

`Traceback (most recent call last):
  File "/opt/conda/envs/rsfms/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/conda/envs/rsfms/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/RSFMs/main_finetune.py", line 29, in <module>
    from engine_finetune import train_one_epoch, evaluate
  File "/home/ubuntu/RSFMs/engine_finetune.py", line 23, in <module>
    from custom_func_finetune import DiceLoss, visualize_segmentation
ModuleNotFoundError: No module named 'custom_func_finetune'`

I was able to work around it by importing the functions from other files. I'm not sure if that's how it should be, so please correct accordingly if necessary. 